### PR TITLE
#if UNITY_EDITOR preprocessor

### DIFF
--- a/Base/HierarchySettingsProvider.cs
+++ b/Base/HierarchySettingsProvider.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
-using static UnityEditor.EditorGUI;
 
 namespace AV.Hierarchy
 {
@@ -104,3 +102,4 @@ namespace AV.Hierarchy
         }
     }
 }
+#endif


### PR DESCRIPTION
Added missing preprocessor to SettingsProvider. Closes #4 

Initially, I didn't made assembly Editor-only because it makes impossible to add Folder MonoBehaviour to game objects (which is very silly restriction).
And because of it, I forgot to wrap new script around #if UNITY_EDITOR preprocessor.

Don't see any workaround without making another assembly (for two lines script..).
Maybe better change how hierarchy looks up for "Folder" objects, so we can get rid of Folder component?