### PR TITLE
Fixed an problem with the "Enable Preview" option in Preference not w…

### DIFF
--- a/Base/SmartHierarchy.cs
+++ b/Base/SmartHierarchy.cs
@@ -26,7 +26,6 @@ namespace AV.Hierarchy
         private ViewItem hoveredItem;
         private bool isHovering => hoveredItem != null;
         private int hoveredItemId => hierarchy.hoveredItem?.id ?? -1;
-        private bool wantsToShowPreview;
         private bool requiresUpdateBeforeGUI;
         private bool requiresGUISetup = true;
         private Vector2 localMousePosition;
@@ -58,7 +57,6 @@ namespace AV.Hierarchy
 
         private void Initialize()
         {
-            wantsToShowPreview = prefs.enableHoverPreview;
             requiresGUISetup = true;
         }
 
@@ -190,8 +188,6 @@ namespace AV.Hierarchy
             // Makes sure other items like scene headers are not interrupted 
             controller.gui.ResetCustomStyling();
             
-            HandleKeyboard(); 
-            
             // Mouse is relative to window during onGUIHandler
             if (evt.type != EventType.Used)
             {
@@ -217,20 +213,19 @@ namespace AV.Hierarchy
             
             controller.gui.SetSpaceBetweenIconAndText(18);
         }
-
-        private void HandleKeyboard()
-        {
-            switch (prefs.previewKey)
-            {
-                case ModificationKey.Alt: wantsToShowPreview = evt.alt; break;
-                case ModificationKey.Shift: wantsToShowPreview = evt.shift; break;
-                case ModificationKey.Control: wantsToShowPreview = evt.control; break;
-            }
-        }
-
+        
         private void HandleObjectPreview()
         {
-            if (isHovering && wantsToShowPreview)
+            var isPreviewKeyHold = false;
+        
+            switch (prefs.previewKey)
+            {
+                case ModificationKey.Alt: isPreviewKeyHold = evt.alt; break;
+                case ModificationKey.Shift: isPreviewKeyHold = evt.shift; break;
+                case ModificationKey.Control: isPreviewKeyHold = evt.control; break;
+            }
+        
+            if (isHovering && prefs.enableHoverPreview && isPreviewKeyHold)
             {
                 hoverPreview.OnItemPreview(hoveredItem);
             }

--- a/UI/smart_hierarchy_settings.uxml
+++ b/UI/smart_hierarchy_settings.uxml
@@ -14,7 +14,7 @@
             <ui:Toggle label="Keep In Playmode" binding-path="keepCollectionsInPlaymode" />
         </ui:Foldout>
         <ui:Foldout text="Objects Preview" name="ObjectsPreview">
-            <ui:Toggle label="Enable Preview" />
+            <ui:Toggle label="Enable Preview" binding-path="enableHoverPreview" />
             <uie:EnumField label="Preview Key" binding-path="previewKey" />
         </ui:Foldout>
         <ui:Foldout text="Components" name="Components">


### PR DESCRIPTION
When I changed the "Enable Preview" option in Preference, I found that it couldn't be selected, and every time I changed it to select and then switched to another Tab, it resets Toggle's state to false, causing the Hover Preview feature to not work. I found out that it was because "Enable Preview" in "smart_hierarchy_settings.uxml" didn't set bindbing-path.